### PR TITLE
Create a cache bust for yum RUN command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,8 @@ rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
-rm -f /lib/systemd/system/anaconda.target.wants/*;
-
-RUN yum -y install ceph ceph-mon ceph-osd --nogpgcheck; yum clean all
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+yum -y install ceph ceph-mon ceph-osd --nogpgcheck; yum clean all
 
 # Editing /etc/redhat-storage-server release file
 RUN echo "Red Hat Ceph Storage Server 2.0 (Container)" > /etc/redhat-storage-release


### PR DESCRIPTION
Combine yum commands into one RUN command. This creates a cache bust to
prevent docker from reusing the cache if we have any future yum command
changes.

Signed-off-by: Ivan Font ivan.font@redhat.com

Docker was inadvertently using the cache and running an old step to install http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm that was adding a repo URL resulting in dependency errors for the ceph package installation step of the Dockerfile. This was generating a bad rhcs 2.0 image that lacked many ceph utilities e.g. ceph-authtool.

The concept of "cache busting" is explained here:
https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
